### PR TITLE
Refactor to use Photos Framework instead of Assets Library framework.

### DIFF
--- a/Example/InstagramAssetsPicker/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/InstagramAssetsPicker/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -7,8 +7,18 @@
     },
     {
       "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "40x40",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
     },
     {
       "idiom" : "iphone",
@@ -48,6 +58,11 @@
     {
       "idiom" : "ipad",
       "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
       "scale" : "2x"
     }
   ],

--- a/Pod/Classes/IGAssetsCollectionViewCell.h
+++ b/Pod/Classes/IGAssetsCollectionViewCell.h
@@ -8,7 +8,8 @@
 
 #import <UIKit/UIKit.h>
 #import <AssetsLibrary/AssetsLibrary.h>
+@import Photos;
 @interface IGAssetsCollectionViewCell : UICollectionViewCell
 
-- (void)applyAsset:(ALAsset *)asset;
+- (void)applyAsset:(PHAsset *)asset;
 @end

--- a/Pod/Classes/IGAssetsCollectionViewCell.m
+++ b/Pod/Classes/IGAssetsCollectionViewCell.m
@@ -9,9 +9,9 @@
 #import "IGAssetsCollectionViewCell.h"
 
 @interface IGAssetsCollectionViewCell()
-@property (nonatomic, strong) ALAsset *asset;
+@property (nonatomic, strong) PHAsset *asset;
 @property (nonatomic, strong) UIImage *image;
-@property (nonatomic, copy) NSString *type;
+@property (nonatomic, assign) PHAssetMediaType type;
 @property (nonatomic, copy) NSString *title;
 
 @end
@@ -51,13 +51,32 @@ static UIColor *videoTitleColor;
     
 }
 
--(void)applyAsset:(ALAsset *)asset
+
+-(void)applyAsset:(PHAsset *)asset
 {
     
     self.asset  = asset;
-    self.image  = [UIImage imageWithCGImage:asset.thumbnail];
-    self.type   = [asset valueForProperty:ALAssetPropertyType];
-    self.title  = [IGAssetsCollectionViewCell getTimeStringOfTimeInterval:[[asset valueForProperty:ALAssetPropertyDuration] doubleValue]];
+    self.type   = [asset mediaType];
+    self.title  = [IGAssetsCollectionViewCell getTimeStringOfTimeInterval:asset.duration];
+    
+    PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
+    options.resizeMode = PHImageRequestOptionsResizeModeExact;
+    options.networkAccessAllowed = true;
+    options.synchronous = true;
+    
+    NSInteger retinaMultiplier = [UIScreen mainScreen].scale;
+    CGSize retinaSquare = CGSizeMake(75 * retinaMultiplier, 75 * retinaMultiplier);
+    
+    [[PHImageManager defaultManager]
+     requestImageForAsset:asset
+     targetSize:retinaSquare
+     contentMode:PHImageContentModeAspectFill
+     options:options
+     resultHandler:^(UIImage *result, NSDictionary *info) {
+         
+         self.image = [UIImage imageWithCGImage:result.CGImage scale:retinaMultiplier orientation:result.imageOrientation];
+         
+     }];
     
 }
 
@@ -73,7 +92,7 @@ static UIColor *videoTitleColor;
     }
     
     // Video duration title
-    if ([self.type isEqual:ALAssetTypeVideo])
+    if (self.type == PHAssetMediaTypeVideo)
     {
         // Create a gradient from transparent to black
         CGFloat colors [] =
@@ -101,9 +120,6 @@ static UIColor *videoTitleColor;
         
         [videoIcon drawAtPoint:CGPointMake(2, startPoint.y + (videoTimeHeight - videoIcon.size.height) / 2)];
     }
-    
-    
-    
     
 }
 

--- a/Pod/Classes/IGAssetsPicker.h
+++ b/Pod/Classes/IGAssetsPicker.h
@@ -11,6 +11,4 @@
 
 #import "IGAssetsPickerViewController.h"
 
-#define IG_CROP_IMMEDIATELY 
-
 #endif

--- a/Pod/Classes/IGAssetsPickerViewController.h
+++ b/Pod/Classes/IGAssetsPickerViewController.h
@@ -9,11 +9,12 @@
 #import <UIKit/UIKit.h>
 #import <AssetsLibrary/AssetsLibrary.h>
 #import <AVFoundation/AVFoundation.h>
+@import Photos;
 
 @protocol IGAssetsPickerDelegate <NSObject>
 
 //get crop region , range:0-1, you can crop when user post for good UE
--(void)IGAssetsPickerGetCropRegion:(CGRect)rect withAlAsset:(ALAsset *)asset;
+-(void)IGAssetsPickerGetCropRegion:(CGRect)rect withPhAsset:(PHAsset *)asset;
 
 //crop immediatly
 -(void)IGAssetsPickerFinishCroppingToAsset:(id)asset;
@@ -22,5 +23,6 @@
 
 @interface IGAssetsPickerViewController : UIViewController
 @property (nonatomic, strong) id<IGAssetsPickerDelegate> delegate;
+@property (readwrite, nonatomic) BOOL cropAfterSelect;
+@property (readwrite, nonatomic) PHFetchOptions *fetchOptions;
 @end
-

--- a/Pod/Classes/IGAssetsPickerViewController.m
+++ b/Pod/Classes/IGAssetsPickerViewController.m
@@ -20,28 +20,29 @@
 @property (strong, nonatomic) IGCropView *cropView;
 
 @property (strong, nonatomic) NSMutableArray *assets;
-@property (strong, nonatomic) ALAssetsLibrary *assetsLibrary;
+@property (strong, nonatomic) PHPhotoLibrary *assetsLibrary;
 
 @property (strong, nonatomic) UICollectionView *collectionView;
 @end
 
 @implementation IGAssetsPickerViewController
-
+@synthesize cropAfterSelect;
+@synthesize fetchOptions;
 
 - (void)loadView {
     [super loadView];
     self.view.backgroundColor = [UIColor blackColor];
-    
+
     [self.view addSubview:self.topView];
     [self.view insertSubview:self.collectionView belowSubview:self.topView];
-    
+
 }
 
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view.
     [self loadPhotos];
-    
+
 }
 
 
@@ -53,50 +54,31 @@
     return _assets;
 }
 
-- (ALAssetsLibrary *)assetsLibrary {
+- (PHPhotoLibrary *)assetsLibrary {
     if (_assetsLibrary == nil) {
-        _assetsLibrary = [[ALAssetsLibrary alloc] init];
+        _assetsLibrary = [[PHPhotoLibrary alloc] init];
     }
     return _assetsLibrary;
 }
 
 - (void)loadPhotos {
     
-    ALAssetsGroupEnumerationResultsBlock assetsEnumerationBlock = ^(ALAsset *result, NSUInteger index, BOOL *stop) {
-        
-        if (result) {
-            [self.assets insertObject:result atIndex:0];
+    PHFetchResult *allMedia = [PHAsset fetchAssetsWithOptions: self.fetchOptions];
+    long mediaCount = [allMedia count];
+    [allMedia enumerateObjectsUsingBlock:^(PHAsset *asset, NSUInteger idx, BOOL *stop) {
+        if (asset) {
+            [self.assets insertObject:asset atIndex:0];
         }
-        
-    };
-    
-    ALAssetsLibraryGroupsEnumerationResultsBlock listGroupBlock = ^(ALAssetsGroup *group, BOOL *stop) {
-        
-        ALAssetsFilter *onlyPhotosFilter = [ALAssetsFilter allAssets];
-        [group setAssetsFilter:onlyPhotosFilter];
-        if ([group numberOfAssets] > 0)
-        {
-            if ([[group valueForProperty:ALAssetsGroupPropertyType] intValue] == ALAssetsGroupSavedPhotos) {
-                [group enumerateAssetsUsingBlock:assetsEnumerationBlock];
-            }
-        }
-        
-        if (group == nil) {
+        if (mediaCount == idx + 1) {
             if (self.assets.count) {
-                ALAsset * asset = [self.assets objectAtIndex:0];
-                [self.cropView setAlAsset:asset];
+                
+                PHAsset *asset = [self.assets objectAtIndex:0];
+                [self.cropView setPhAsset:asset];
+                [self.collectionView reloadData];
             }
-            [self.collectionView reloadData];
         }
-        
-        
-    };
-    
-    [self.assetsLibrary enumerateGroupsWithTypes:ALAssetsGroupAll usingBlock:listGroupBlock failureBlock:^(NSError *error) {
-        NSLog(@"Load Photos Error: %@", error);
     }];
-    
-    
+
 }
 
 
@@ -112,19 +94,19 @@
         self.topView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleBottomMargin;
         self.topView.backgroundColor = [UIColor clearColor];
         self.topView.clipsToBounds = YES;
-        
+
         rect = CGRectMake(0, 0, CGRectGetWidth(self.topView.bounds), handleHeight);
         UIView *navView = [[UIView alloc] initWithFrame:rect];//26 29 33
         navView.backgroundColor = [[UIColor colorWithRed:26.0/255 green:29.0/255 blue:33.0/255 alpha:1] colorWithAlphaComponent:.8f];
         [self.topView addSubview:navView];
-        
+
         rect = CGRectMake(0, 0, 60, CGRectGetHeight(navView.bounds));
         UIButton *backBtn = [UIButton buttonWithType:UIButtonTypeCustom];
         backBtn.frame = rect;
         [backBtn setImage:[UIImage imageNamed:@"InstagramAssetsPicker.bundle/back"] forState:UIControlStateNormal];
         [backBtn addTarget:self action:@selector(backAction) forControlEvents:UIControlEventTouchUpInside];
         [navView addSubview:backBtn];
-        
+
         rect = CGRectMake((CGRectGetWidth(navView.bounds)-100)/2, 0, 100, CGRectGetHeight(navView.bounds));
         UILabel *titleLabel = [[UILabel alloc] initWithFrame:rect];
         titleLabel.text = @"SELECT";
@@ -133,7 +115,7 @@
         titleLabel.textColor = [UIColor whiteColor];
         titleLabel.font = [UIFont boldSystemFontOfSize:18.0f];
         [navView addSubview:titleLabel];
-        
+
         rect = CGRectMake(CGRectGetWidth(navView.bounds)-80, 0, 80, CGRectGetHeight(navView.bounds));
         UIButton *cropBtn = [[UIButton alloc] initWithFrame:rect];
         [cropBtn setTitle:@"OK" forState:UIControlStateNormal];
@@ -141,37 +123,38 @@
         [cropBtn setTitleColor:[UIColor cyanColor] forState:UIControlStateNormal];
         [cropBtn addTarget:self action:@selector(cropAction) forControlEvents:UIControlEventTouchUpInside];
         [navView addSubview:cropBtn];
-        
+
         rect = CGRectMake(0, CGRectGetHeight(self.topView.bounds)-handleHeight, CGRectGetWidth(self.topView.bounds), handleHeight);
         UIView *dragView = [[UIView alloc] initWithFrame:rect];
         dragView.backgroundColor = navView.backgroundColor;
         dragView.autoresizingMask = UIViewAutoresizingFlexibleTopMargin;
         [self.topView addSubview:dragView];
-        
+
         UIImage *img = [UIImage imageNamed:@"InstagramAssetsPicker.bundle/cameraroll-picker-grip"];
         rect = CGRectMake((CGRectGetWidth(dragView.bounds)-img.size.width)/2, (CGRectGetHeight(dragView.bounds)-img.size.height)/2, img.size.width, img.size.height);
         UIImageView *gripView = [[UIImageView alloc] initWithFrame:rect];
         gripView.image = img;
         [dragView addSubview:gripView];
-        
+
         UIPanGestureRecognizer *panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panGestureAction:)];
         [dragView addGestureRecognizer:panGesture];
-        
+
         UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapGestureAction:)];
         [dragView addGestureRecognizer:tapGesture];
-        
+
         [tapGesture requireGestureRecognizerToFail:panGesture];
-        
+
         rect = CGRectMake(0, handleHeight, CGRectGetWidth(self.topView.bounds), CGRectGetHeight(self.topView.bounds)-handleHeight*2);
         self.cropView = [[IGCropView alloc] initWithFrame:rect];
         [self.topView addSubview:self.cropView];
         [self.topView sendSubviewToBack:self.cropView];
-        
+
         self.maskView = [[UIImageView alloc] initWithFrame:rect];
         self.maskView.image = [UIImage imageNamed:@"InstagramAssetsPicker.bundle/straighten-grid"];
-        [self.topView insertSubview:self.maskView aboveSubview:self.cropView];
-        
-        
+
+        UIPanGestureRecognizer *cropViewPanGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(cropViewPanGestureAction:)];
+        [self.cropView addGestureRecognizer:cropViewPanGesture];
+
     }
     return _topView;
 }
@@ -180,22 +163,22 @@
     if (_collectionView == nil) {
         CGFloat colum = 4.0, spacing = 2.0;
         CGFloat value = floorf((CGRectGetWidth(self.view.bounds) - (colum - 1) * spacing) / colum);
-        
+
         UICollectionViewFlowLayout *layout  = [[UICollectionViewFlowLayout alloc] init];
         layout.itemSize                     = CGSizeMake(value, value);
         layout.sectionInset                 = UIEdgeInsetsMake(0, 0, 0, 0);
         layout.minimumInteritemSpacing      = spacing;
         layout.minimumLineSpacing           = spacing;
-        
+
         CGRect rect = CGRectMake(0, CGRectGetMaxY(self.topView.frame), CGRectGetWidth(self.view.bounds), CGRectGetHeight(self.view.bounds)-CGRectGetHeight(self.topView.bounds));
         _collectionView = [[UICollectionView alloc] initWithFrame:rect collectionViewLayout:layout];
         _collectionView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         _collectionView.dataSource = self;
         _collectionView.delegate = self;
         _collectionView.backgroundColor = [UIColor clearColor];
-        
+
         [_collectionView registerClass:[IGAssetsCollectionViewCell class] forCellWithReuseIdentifier:@"IGAssetsCollectionViewCell"];
-        
+
         //        rect = CGRectMake(0, 0, 60, layout.sectionInset.top);
         //        UIButton *backBtn = [UIButton buttonWithType:UIButtonTypeCustom];
         //        backBtn.frame = rect;
@@ -219,25 +202,27 @@
     [self dismissViewControllerAnimated:YES completion:NULL];
 }
 
+
 - (void)cropAction {
-    
-#ifdef IG_CROP_IMMEDIATELY
-    
-    if(self.delegate && [self.delegate respondsToSelector:@selector(IGAssetsPickerFinishCroppingToAsset:)])
+    if (cropAfterSelect)
     {
-        id asset = [self.cropView cropAsset];
-        [self.delegate IGAssetsPickerFinishCroppingToAsset:asset];
-        
+        if(self.delegate && [self.delegate respondsToSelector:@selector(IGAssetsPickerFinishCroppingToAsset:)])
+        {
+            [self.cropView cropAsset:^(id asset) {
+                [self.delegate IGAssetsPickerFinishCroppingToAsset:asset];
+            }];
+        }
     }
-#else
-    if(self.delegate && [self.delegate respondsToSelector:@selector(IGAssetsPickerGetCropRegion: withAlAsset:)])
+    else
     {
-        CGRect rect = [self.cropView getCropRegion];
-        [self.delegate IGAssetsPickerGetCropRegion:rect withAlAsset:self.cropView.alAsset];
+        if(self.delegate && [self.delegate respondsToSelector:@selector(IGAssetsPickerGetCropRegion: withPhAsset:)])
+        {
+            [self.cropView getCropRegion:^(CGRect rect) {
+                [self.delegate IGAssetsPickerGetCropRegion:rect withPhAsset:self.cropView.phAsset];
+            }];
+        }
     }
-
-#endif
-
+    
     [self backAction];
 }
 
@@ -255,7 +240,7 @@
             } else if (endOriginY < beginOriginY) {
                 topFrame.origin.y = (beginOriginY - endOriginY) >= 20 ? -(CGRectGetHeight(self.topView.bounds)-20-44) : 0;
             }
-            
+
             CGRect collectionFrame = self.collectionView.frame;
             collectionFrame.origin.y = CGRectGetMaxY(topFrame);
             collectionFrame.size.height = CGRectGetHeight(self.view.bounds) - CGRectGetMaxY(topFrame);
@@ -275,16 +260,36 @@
             CGPoint translation = [panGesture translationInView:self.view];
             CGRect topFrame = self.topView.frame;
             topFrame.origin.y = translation.y + beginOriginY;
-            
+
             CGRect collectionFrame = self.collectionView.frame;
             collectionFrame.origin.y = CGRectGetMaxY(topFrame);
             collectionFrame.size.height = CGRectGetHeight(self.view.bounds) - CGRectGetMaxY(topFrame);
-            
+
             if (topFrame.origin.y <= 0 && (topFrame.origin.y >= -(CGRectGetHeight(self.topView.bounds)-20-44))) {
                 self.topView.frame = topFrame;
                 self.collectionView.frame = collectionFrame;
             }
-            
+
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+- (void)cropViewPanGestureAction:(UIPanGestureRecognizer *)panGesture {
+    switch (panGesture.state)
+    {
+        case UIGestureRecognizerStateEnded:
+        case UIGestureRecognizerStateCancelled:
+        case UIGestureRecognizerStateFailed:
+        {
+            [self.maskView removeFromSuperview];
+            break;
+        }
+        case UIGestureRecognizerStateBegan:
+        {
+            [self.topView insertSubview:self.maskView aboveSubview:self.cropView];
             break;
         }
         default:
@@ -295,14 +300,14 @@
 - (void)tapGestureAction:(UITapGestureRecognizer *)tapGesture {
     CGRect topFrame = self.topView.frame;
     topFrame.origin.y = topFrame.origin.y == 0 ? -(CGRectGetHeight(self.topView.bounds)-20-44) : 0;
-    
+
     CGRect collectionFrame = self.collectionView.frame;
     collectionFrame.origin.y = CGRectGetMaxY(topFrame);
     collectionFrame.size.height = CGRectGetHeight(self.view.bounds) - CGRectGetMaxY(topFrame);
     [UIView animateWithDuration:.3f animations:^{
         self.topView.frame = topFrame;
         self.collectionView.frame = collectionFrame;
-        
+
     }];
 }
 
@@ -321,7 +326,7 @@
 - (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath
 {
     static NSString *CellIdentifier = @"IGAssetsCollectionViewCell";
-    
+
     IGAssetsCollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:CellIdentifier forIndexPath:indexPath];
     [cell applyAsset:[self.assets objectAtIndex:indexPath.row]];
     return cell;
@@ -332,9 +337,9 @@
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
     
-    ALAsset * asset = [self.assets objectAtIndex:indexPath.row];
+    PHAsset *asset = [self.assets objectAtIndex:indexPath.row];
     
-    [self.cropView setAlAsset:asset];
+    [self.cropView setPhAsset:asset];
     
     UICollectionViewCell * cell = [collectionView cellForItemAtIndexPath:indexPath];
     
@@ -347,7 +352,7 @@
 
 - (void)collectionView:(UICollectionView *)collectionView didDeselectItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    
+
 }
 
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset {

--- a/Pod/Classes/IGCropView.h
+++ b/Pod/Classes/IGCropView.h
@@ -11,14 +11,17 @@
 #import <MediaPlayer/MediaPlayer.h>
 #import <AVFoundation/AVFoundation.h>
 
+@import Photos;
+
 @interface IGCropView : UIScrollView
 @property (nonatomic, strong) ALAsset * alAsset;
+@property (nonatomic, strong) PHAsset * phAsset;
 
-- (id)cropAsset;
+- (void)cropAsset:(void(^)(id))completeBlock;
 
-- (CGRect)getCropRegion;
+- (void)getCropRegion:(void(^)(CGRect))completeBlock;
 
 //for lately crop
-+(id)cropAlAsset:(ALAsset *)asset withRegion:(CGRect)rect;
++(void)cropPhAsset:(PHAsset *)asset withRegion:(CGRect)rect onComplete:(void(^)(id))completion;
 
 @end

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ With [CocoaPods](http://cocoapods.org/), add this line to your Podfile.
 #import "IGAssetsPicker.h"
 IGAssetsPickerViewController *picker = [[IGAssetsPickerViewController alloc] init];
 picker.delegate = self;
+picker.cropAfterSelect = true;
 [self presentViewController:picker animated:YES completion:NULL];
+
 ```
-if you want crop the asset later,you should comment the `IG_CROP_IMMEDIATELY` define in `IGAssetsPicker.h`
+If you want to crop the asset later, set `cropAfterSelect` to `false` on the `IGAssetsPickerViewController` instance.
 
 ## Author
 
@@ -38,4 +40,3 @@ if you want crop the asset later,you should comment the `IG_CROP_IMMEDIATELY` de
 ## License
 
 InstagramAssetsPicker is available under the MIT license. See the LICENSE file for more info.
-


### PR DESCRIPTION
This PR makes the assets picker use the Photos Framework.  [The Assets Library is deprecated as of iOS 9.0](https://developer.apple.com/library/ios/documentation/AssetsLibrary/Reference/AssetsLibraryFramework/)
